### PR TITLE
Improve palette decoding and fix lyrics overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/functions/palette.ts
+++ b/functions/palette.ts
@@ -1,4 +1,5 @@
-import decodeJpeg from "./lib/vendor/jpeg-decoder.js";
+import legacyDecodeJpeg from "./lib/vendor/jpeg-decoder.js";
+import { decode as robustDecodeJpeg } from "jpeg-js";
 
 const MAX_DIMENSION = 96;
 const TARGET_SAMPLE_COUNT = 2400;
@@ -287,6 +288,24 @@ function resizeImage(image: DecodedImage): DecodedImage {
   };
 }
 
+function toClampedArray(data: ArrayLike<number>): Uint8ClampedArray {
+  if (data instanceof Uint8ClampedArray) {
+    return data;
+  }
+
+  if (data instanceof Uint8Array) {
+    return new Uint8ClampedArray(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength));
+  }
+
+  const length = data.length;
+  const clamped = new Uint8ClampedArray(length);
+  for (let index = 0; index < length; index += 1) {
+    const value = data[index];
+    clamped[index] = typeof value === "number" ? value : 0;
+  }
+  return clamped;
+}
+
 function decodeImage(arrayBuffer: ArrayBuffer, contentType: string): DecodedImage {
   const subtype = contentType.split("/")[1]?.split(";")[0]?.toLowerCase() ?? "";
   const supported: SupportedFormat[] = ["jpeg", "jpg", "pjpeg"];
@@ -295,18 +314,52 @@ function decodeImage(arrayBuffer: ArrayBuffer, contentType: string): DecodedImag
   }
 
   const bytes = new Uint8Array(arrayBuffer);
-  const decoded = decodeJpeg(bytes, {
-    useTArray: true,
-    formatAsRGBA: true,
-  });
 
-  const image: DecodedImage = {
-    width: decoded.width,
-    height: decoded.height,
-    data: new Uint8ClampedArray(decoded.data),
+  const decodeWithLegacy = () => {
+    const result = legacyDecodeJpeg(bytes, {
+      useTArray: true,
+      formatAsRGBA: true,
+    });
+
+    return {
+      width: result.width,
+      height: result.height,
+      data: toClampedArray(result.data),
+    };
   };
 
-  return resizeImage(image);
+  const decodeWithRobust = () => {
+    const result = robustDecodeJpeg(bytes, {
+      useTArray: true,
+      formatAsRGBA: true,
+      tolerantDecoding: true,
+    });
+
+    return {
+      width: result.width,
+      height: result.height,
+      data: toClampedArray(result.data),
+    };
+  };
+
+  let decoded: DecodedImage;
+  try {
+    decoded = decodeWithLegacy();
+  } catch (primaryError) {
+    console.warn("Legacy JPEG decoder failed, falling back to jpeg-js", primaryError);
+    try {
+      decoded = decodeWithRobust();
+    } catch (fallbackError) {
+      console.error("jpeg-js fallback decoder failed", fallbackError);
+      const primaryMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
+      const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+      const combined = new Error(`Failed to decode JPEG image (primary: ${primaryMessage}; fallback: ${fallbackMessage})`);
+      (combined as Error & { cause?: unknown }).cause = fallbackError;
+      throw combined;
+    }
+  }
+
+  return resizeImage(decoded);
 }
 
 async function buildPalette(arrayBuffer: ArrayBuffer, contentType: string): Promise<PaletteResponse> {

--- a/index.html
+++ b/index.html
@@ -844,6 +844,7 @@
             flex: 1;
             width: 100%;
             overflow-y: auto;
+            overflow-x: hidden;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -861,6 +862,7 @@
 
         .lyrics-content {
             width: 100%;
+            overflow-x: hidden;
         }
 
         .lyrics-content > div {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "music-player",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "music-player",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "jpeg-js": "^0.4.4"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "music-player",
+  "version": "1.0.0",
+  "description": "> 🌐 一个无需后端即可部署的现代化网页音乐播放器，整合音乐聚合接口，集搜索、播放、歌词与下载于一体。",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "jpeg-js": "^0.4.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add a jpeg-js fallback decoder so palette generation no longer fails on problematic covers
- persist the new dependency metadata and ignore local node_modules installs
- hide horizontal overflow in the lyrics panel to remove the stray scrollbar

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e405245294832b994063fa61780b7a